### PR TITLE
fix build error: assignment mismatch

### DIFF
--- a/internal/play/play.go
+++ b/internal/play/play.go
@@ -64,13 +64,9 @@ func (f *flags) do_delivery() error {
       if !ok {
          break
       }
-      if address, ok := apk.Url(); ok {
-         if v, ok := apk.Field1(); ok {
-            err := download(address, f.app.Apk(v))
-            if err != nil {
-               return err
-            }
-         }
+      err := download(apk.Url(), f.app.Apk(apk.Field1()))
+      if err != nil {
+         return err
       }
    }
    obbs := deliver.Obb()
@@ -79,20 +75,14 @@ func (f *flags) do_delivery() error {
       if !ok {
          break
       }
-      if address, ok := obb.Url(); ok {
-         if v, ok := obb.Field1(); ok {
-            err := download(address, f.app.Obb(v))
-            if err != nil {
-               return err
-            }
-         }
-      }
-   }
-   if v, ok := deliver.Url(); ok {
-      err := download(v, f.app.Apk(""))
+      err := download(obb.Url(), f.app.Obb(obb.Field1()))
       if err != nil {
          return err
       }
+   }
+   err = download(deliver.Url(), f.app.Apk(""))
+   if err != nil {
+      return err
    }
    return nil
 }


### PR DESCRIPTION
These errors appear when I build this package:

```
# 41.neocities.org/google/internal/play
internal/play/play.go:67:25: assignment mismatch: 2 variables but apk.Url returns 1 value
internal/play/play.go:68:22: assignment mismatch: 2 variables but apk.Field1 returns 1 value
internal/play/play.go:82:25: assignment mismatch: 2 variables but obb.Url returns 1 value
internal/play/play.go:83:22: assignment mismatch: 2 variables but obb.Field1 returns 1 value
internal/play/play.go:91:16: assignment mismatch: 2 variables but deliver.Url returns 1 value
```

The errors were introduced in a5493ee recently. This PR fixes the errors.